### PR TITLE
dockerfiles: add python-pip aka pip2. Needed for tests.

### DIFF
--- a/dockerfiles/Dockerfile.toolchain-base
+++ b/dockerfiles/Dockerfile.toolchain-base
@@ -32,6 +32,7 @@ RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y -qq \
   automake \
   libtool \
   python \
+  python-pip \
   python3 \
   python3-pip \
   libsdl1.2-dev  \


### PR DESCRIPTION
Signed-off-by: bavery <brian.avery@intel.com>