### PR TITLE
helpers: add a delay after starting rethinkdb to avoid race

### DIFF
--- a/helpers/startCodi.sh
+++ b/helpers/startCodi.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 /etc/init.d/rethinkdb start
+sleep 5
 python3 -m launchers.codi-launcher


### PR DESCRIPTION
TODO: if this solves the codi connect issue, we need to move
the logic into codi and have it cycle and retry the socket
connection and NOT rely on a bash sleep.

Signed-off-by: bavery <brian.avery@intel.com>